### PR TITLE
hotfix/1.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * **Persistent Queue**: Events and Entities are saved to a queue that is persisted to localStorage, or another storage method of your choice.
 * **Convenience Methods**: Easily start and end Sessions with simplified methods.
 * **Session Keep-Alive**: The current Session's `dateModified` is periodically updated and sent to the EventStore to track Session activity before it is ended.
-* **Session End**: Sessions are ended automatically when the user is idle (no mouse, touch, keyboard, scroll events) or away from the app for longer than the `sessionEndThreshold`. 
+* **Session Timeout**: Sessions are ended automatically (timed out) when the user is idle (no mouse, touch, keyboard, scroll events) or away from the app for longer than the `sessionTimeoutThreshold`. 
 
 ## Installation
 
@@ -53,6 +53,7 @@ You can then access the JavaScript global parameter `StudioKit`.
 | autoSend | false | boolean | Whether or not to send the queue of Caliper events on a timer. | true |
 | sendInterval | false | number (milliseconds) | How often a request containing the current queue of Caliper events is sent, enabled by `autoSend`. | `1000 * 10` // 10 seconds |
 | sessionIriPrefix | false | string | The value with which to prefix all Caliper Session `@id` values. Will be prefixed to form valid IRI, e.g. `${sessionIriPrefix}/session/${uuid}` | `null`, defaults to `appId` |
-| sessionEndThreshold | false | number (milliseconds) | The amount of time a Session can be idle (e.g. no mouse, keyboard, touch, or scroll events) before the Session is ended. | `1000 * 60 * 30` // 30 minutes |
-| sessionKeepAliveThreshold | false | number (milliseconds) | How often the "keep alive" request will be sent. | `1000 * 60 * 15`  // 15 minutes |
+| sessionTimeoutThreshold | false | number (milliseconds) | The amount of time a Session can be idle (e.g. no mouse, keyboard, touch, or scroll events) before the Session is ended as `TIMED_OUT`. | `1000 * 60 * 30` // 30 minutes |
+| sessionKeepAliveThreshold | false | number (milliseconds) | How often activity should trigger the Session to be "kept alive" by having its `dateModified` updated, and sent to the EventStore. | `1000 * 60 * 15`  // 15 minutes |
+| activityUpdateThreshold | false | number (milliseconds) | How often the activity sent to `onActivity()` (e.g. mouse, keyboard, touch, or scroll events, or manual calls) is processed. | `1000 * 60`  // 1 minute |
 | onError | false | function | A function that is called when an error is encountered, e.g. `function(err) {}` | `console.error(err)` |

--- a/lib/caliper-service.js
+++ b/lib/caliper-service.js
@@ -38,15 +38,17 @@ function CaliperService(options) {
 
 	var personKey = 'studioKit:caliperService:person';
 	var sessionKey = 'studioKit:caliperService:session';
+	var sessionExtensionsKey = 'studioKit:caliperService:sessionExtensions';
 	var lastActivityDateKey = 'studioKit:caliperService:lastActivityDate';
 	var lastKeepAliveDateKey = 'studioKit:caliperService:lastKeepAliveDate';
-	
+
 	var sessionEndTimeout;
 
 	// Persistent objects
 	var softwareApplication;
 	var person;
 	var session;
+	var sessionExtensions;
 	var lastActivityDate = null;
 	var lastKeepAliveDate = null;
 
@@ -64,9 +66,10 @@ function CaliperService(options) {
 		autoSend: true,
 		sendInterval: 1000 * 10, // 10 seconds
 		sessionIriPrefix: null,
-		sessionEndThreshold:  1000 * 60 * 30, // 30 minutes
-		sessionKeepAliveThreshold: 1000 * 60 * 15, // 15 minutes
-		onError: function(err) {
+		sessionTimeoutThreshold: 1000 * 60 * 30, // 30 minutes
+		sessionKeepAliveThreshold: 1000 * 60 * 15, // 15 minutes,
+		activityUpdateThreshold: 1000 * 60, // 1 minute
+		onError: function (err) {
 			console.error(err);
 		}
 	};
@@ -124,11 +127,14 @@ function CaliperService(options) {
 		if (!_.isNil(options.sessionIriPrefix) && (!_.isString(options.sessionIriPrefix) || options.sessionIriPrefix.length === 0)) {
 			throw new Error('`options.sessionIriPrefix` must be a string');
 		}
-		if (!_.isFinite(options.sessionEndThreshold)) {
-			throw new Error('`options.sessionEndThreshold` must be a number');
+		if (!_.isFinite(options.sessionTimeoutThreshold)) {
+			throw new Error('`options.sessionTimeoutThreshold` must be a number');
 		}
 		if (!_.isFinite(options.sessionKeepAliveThreshold)) {
 			throw new Error('`options.sessionKeepAliveThreshold` must be a number');
+		}
+		if (!_.isFinite(options.activityUpdateThreshold)) {
+			throw new Error('`options.activityUpdateThreshold` must be a number');
 		}
 		if (!_.isFunction(options.onError)) {
 			throw new Error('`options.onError` function is required');
@@ -184,52 +190,91 @@ function CaliperService(options) {
 		authToken = _options.storageService.getItem(authTokenKey) || null;
 		person = _options.storageService.getItem(personKey) || null;
 		session = _options.storageService.getItem(sessionKey) || null;
+		sessionExtensions = _options.storageService.getItem(sessionExtensionsKey) || null;
 		lastKeepAliveDate = _options.storageService.getItem(lastKeepAliveDateKey) || null;
 		lastActivityDate = _options.storageService.getItem(lastActivityDateKey)
 			// backwards compatible with v1.0.10
-			|| _options.storageService.getItem('studioKit:caliperService:sessionPauseDate') 
-			|| null;
+			||
+			_options.storageService.getItem('studioKit:caliperService:sessionPauseDate') ||
+			null;
 	}
 
 	/**
 	 * Handle a saved Session. 
-	 * 1. Clears the Session if it cannot resume or end.
-	 * 2. Resumes the Session if it is within the timeout threshold.
-	 * 3. Ends the Session and starts a new Session if it is beyond the timeout threshold.
+	 * 1. Clears the Session if there is not enough saved data.
+	 * 2. Resumes the Session if it exists and is within the timeout threshold.
+	 * 3. Ends the Session (if any) and starts a new Session if it is beyond the timeout threshold.
 	 */
 	function handleSavedSession() {
 		// clear saved data if not all required items are found
-		if (_.isNil(session) || _.isNil(person) || _.isNil(lastActivityDate)) {
-			clearSavedSession();
-			clearSavedPerson();
+		if (_.isNil(person) || _.isNil(lastActivityDate)) {
+			logger('handleSavedSession', 'clear saved session');
+			clearSession();
+			clearSessionExtensions();
+			clearPerson();
+			clearLastActivityDate();
+			clearLastKeepAliveDate();
 			return;
 		}
 
 		// resume session
-		if (moment().diff(moment(lastActivityDate)) <= _options.sessionEndThreshold) {
-			restartSessionEndTimeout();
+		if (!_.isNil(session) && moment().diff(moment(lastActivityDate)) <= _options.sessionTimeoutThreshold) {
+			logger('handleSavedSession', 'lastActivityDate within sessionTimeoutThreshold, resume session');
+			// trigger activity to start session timer
+			onActivity();
 			return;
 		}
 
-		// close previous session
-		// save refs to person, session.extensions
-		var extensionsRef = session.extensions;
-		var personRef = person;
-		endSession(lastActivityDate);
+		logger('handleSavedSession', 'lastActivityDate past sessionTimeoutThreshold, start new session');
 
-		// endSession clears the person, reset it
-		person = personRef;
-		startSession(extensionsRef);
+		// end previous session as a time out (if any)
+		if (!_.isNil(session)) {
+			endSession(lastActivityDate, true);
+		}
+
+		// start new session, with extensions (if any)
+		startSession(sessionExtensions);
 	}
 
-	function clearSavedPerson() {
+	function setSessionExtensions(extensions) {
+		sessionExtensions = extensions;
+		_options.storageService.setItem(sessionExtensionsKey, sessionExtensions);
+	}
+
+	function setLastKeepAliveDate(isoString) {
+		lastKeepAliveDate = isoString;
+		_options.storageService.setItem(lastKeepAliveDateKey, lastKeepAliveDate);
+	}
+
+	function setLastActivityDate(isoString) {
+		logger('setLastActivityDate', isoString);
+		lastActivityDate = isoString;
+		_options.storageService.setItem(lastActivityDateKey, lastActivityDate);
+	}
+
+	function clearPerson() {
 		person = null;
 		_options.storageService.setItem(personKey, null);
 	}
 
-	function clearSavedSession() {
+	function clearSession() {
 		session = null;
 		_options.storageService.setItem(sessionKey, null);
+	}
+
+	function clearSessionExtensions() {
+		sessionExtensions = null;
+		_options.storageService.setItem(sessionExtensionsKey, null);
+	}
+
+	function clearLastKeepAliveDate() {
+		lastKeepAliveDate = null;
+		_options.storageService.setItem(lastKeepAliveDateKey, null);
+	}
+
+	function clearLastActivityDate() {
+		lastActivityDate = null;
+		_options.storageService.setItem(lastActivityDateKey, null);
 	}
 
 	//
@@ -269,7 +314,7 @@ function CaliperService(options) {
 
 	function getAuthToken() {
 		return _options.getToken()
-			.then(function(token) {
+			.then(function (token) {
 				if (_.isNil(token)) {
 					throw new Error('Error with `getToken` response: A response is required.');
 				}
@@ -284,7 +329,7 @@ function CaliperService(options) {
 				authToken = token;
 				updateSensorToken(authToken);
 			})
-			.catch(function(error) {
+			.catch(function (error) {
 				errorLogger('GET Caliper EventStore Token Error', error);
 				_options.storageService.removeItem(authTokenKey);
 				authToken = null;
@@ -293,7 +338,7 @@ function CaliperService(options) {
 	}
 
 	function getOrRefreshAuthToken() {
-		return new Promise(function(resolve, reject) {
+		return new Promise(function (resolve, reject) {
 			if (hasAuthToken() && !isAuthTokenExpired()) {
 				updateSensorToken(authToken);
 				resolve(authToken);
@@ -315,7 +360,7 @@ function CaliperService(options) {
 
 	/**
 	 * Send events to the EventStore
-	 * @param maxEvents - maximum number of events to send at once. -1 will send the entire queue.
+	 * @param {number} maxEvents The maximum number of events to send at once. -1 will send the entire queue.
 	 */
 	function send(maxEvents) {
 		maxEvents = maxEvents || -1;
@@ -341,21 +386,21 @@ function CaliperService(options) {
 		logger('Sending Caliper Events...', eventsToSend);
 
 		sendPromise = getOrRefreshAuthToken()
-			.catch(function(error) {
+			.catch(function (error) {
 				errorLogger('Caliper Token Error', error);
 				sendPromise = null;
 				_options.onError(error);
 				throw error;
 			})
-			.then(function() {
+			.then(function () {
 				return Caliper.Sensor.send(eventsToSend)
-					.then(function(response) {
+					.then(function (response) {
 						logger('Caliper Events Saved', response);
 						// remove the saved events from the queue
 						queue = _.difference(queue, eventsToSend);
 						options.storageService.setItem(queueKey, queue);
 						sendPromise = null;
-					}).catch(function(error) {
+					}).catch(function (error) {
 						if (error instanceof StandardHttpError) {
 							if (error.code === 401) {
 								// clear auth token for an Unauthorized response
@@ -386,11 +431,11 @@ function CaliperService(options) {
 			return;
 		}
 		return send()
-			.then(function() {
+			.then(function () {
 				startAutoSendTimeout();
 				return true;
 			})
-			.catch(function() {
+			.catch(function () {
 				startAutoSendTimeout();
 				return false;
 			});
@@ -408,20 +453,31 @@ function CaliperService(options) {
 	//
 
 	function onActivity(e) {
+		if (!isInitialized) {
+			return;
+		}
+
 		var now = moment();
 
 		// limit updates to once per minute
-		if (now.diff(moment(lastActivityDate)) < (1000 * 60)) {
+		if (now.diff(moment(lastActivityDate)) < _options.activityUpdateThreshold) {
 			return;
 		}
 
 		logger('onActivity', e);
 
-		// save date of activity
-		lastActivityDate = now.toISOString();
-		_options.storageService.setItem(lastActivityDateKey, lastActivityDate);
+		var didStartSession = false;
+		if (_.isNil(session) && !_.isNil(person)) {
+			// start new session, with extensions (if any)
+			startSession(sessionExtensions);
+			didStartSession = true;
+		}
 
-		if (!_.isNil(session)) {
+		// save date of activity
+		setLastActivityDate(now.toISOString());
+
+		// update timer and keep-alive
+		if (!_.isNil(session) && !didStartSession) {
 			// restart session end timeout
 			startSessionEndTimeout();
 
@@ -461,11 +517,11 @@ function CaliperService(options) {
 			return false;
 		}
 		var isVideoPlaying = Array.prototype.slice.call(document.getElementsByTagName('video'))
-			.some(function(video) {
+			.some(function (video) {
 				return video.currentTime > 0 && !video.paused && !video.ended && video.readyState > 2;
 			});
 		var isAudioPlaying = Array.prototype.slice.call(document.getElementsByTagName('audio'))
-			.some(function(audio) {
+			.some(function (audio) {
 				return audio.currentTime > 0 && !audio.paused && !audio.ended && audio.readyState > 2;
 			});
 		return isVideoPlaying || isAudioPlaying;
@@ -474,22 +530,15 @@ function CaliperService(options) {
 	function startSessionEndTimeout() {
 		clearSessionEndTimeout();
 		logger('startSessionEndTimeout');
-		sessionEndTimeout = setTimeout(function() {
-			if (isMediaPlaying()) {
+		sessionEndTimeout = setTimeout(function () {
+			if (service.isMediaPlaying()) { // call service method to enable test stubs
 				logger('media is playing');
-				restartSessionEndTimeout();
+				onActivity();
 				return;
 			}
-			endSession(lastActivityDate);
-		}, _options.sessionEndThreshold);
-	}
-
-	function restartSessionEndTimeout() {
-		logger('restartSessionEndTimeout');
-		// trigger update activity date (if needed)
-		onActivity();
-		// force start session end timeout
-		startSessionEndTimeout();
+			// end session, timed out
+			endSession(lastActivityDate, true);
+		}, _options.sessionTimeoutThreshold);
 	}
 
 	function clearSessionEndTimeout() {
@@ -563,6 +612,7 @@ function CaliperService(options) {
 
 		if (!_.isNil(extensions)) {
 			session.extensions = extensions;
+			setSessionExtensions(extensions);
 		}
 
 		// create Event
@@ -582,10 +632,10 @@ function CaliperService(options) {
 		_options.storageService.setItem(sessionKey, session);
 
 		// save date to storageService so keep alive always has a starting point
-		lastKeepAliveDate = nowISOString;
-		_options.storageService.setItem(lastKeepAliveDateKey, nowISOString);
+		setLastKeepAliveDate(nowISOString);
 
-		restartSessionEndTimeout();
+		// trigger activity to start session timer
+		onActivity();
 	}
 
 	function keepAliveSession() {
@@ -612,11 +662,15 @@ function CaliperService(options) {
 		addToQueue(minSession);
 
 		// save date to storageService
-		lastKeepAliveDate = nowISOString;
-		_options.storageService.setItem(lastKeepAliveDateKey, nowISOString);
+		setLastKeepAliveDate(nowISOString);
 	}
 
-	function endSession(endedAtTime) {
+	/**
+	 * Ends the Session in progress.
+	 * @param {string} endedAtTime The ISO Date string when the Session ended. By default, the current moment is used.
+	 * @param {boolean} didTimeOut Whether or not the Session timed out. By default, the SessionEvent's action will be LOGGED_OUT.
+	 */
+	function endSession(endedAtTime, didTimeOut) {
 		checkIsInitialized();
 
 		if (_.isNil(person)) {
@@ -628,13 +682,16 @@ function CaliperService(options) {
 
 		// end Session
 		endedAtTime = endedAtTime || moment().toISOString();
+		didTimeOut = didTimeOut || false;
+
 		session.endedAtTime = endedAtTime;
 		session.dateModified = endedAtTime;
 
 		// create Event
 		var event = new Caliper.Events.SessionEvent();
+		var action = didTimeOut ? Caliper.Actions.SessionActions.TIMED_OUT : Caliper.Actions.SessionActions.LOGGED_OUT;
 		event.setActor(person);
-		event.setAction(Caliper.Actions.SessionActions.LOGGED_OUT);
+		event.setAction(action);
 		event.setObject(session);
 		event.setEventTime(endedAtTime);
 		event.setEdApp(softwareApplication);
@@ -643,22 +700,29 @@ function CaliperService(options) {
 		logger('endSession', event);
 		addToQueue(event);
 
-		clearSavedSession();
-		clearSavedPerson();
+		clearSession();
+		clearLastKeepAliveDate();
 		clearSessionEndTimeout();
+
+		if (!didTimeOut) {
+			clearLastActivityDate();
+			clearPerson();
+			clearSessionExtensions();
+		}
 	}
 
 	//
 	// Public Methods
 	//
 
-	service.isInitialized = function() {
+	service.isInitialized = function () {
 		return isInitialized;
 	};
 	service.getOrRefreshAuthToken = getOrRefreshAuthToken;
 	service.addToQueue = addToQueue;
 	service.send = send;
 	service.onActivity = onActivity;
+	service.isMediaPlaying = isMediaPlaying;
 	service.setPerson = setPerson;
 	service.startSession = startSession;
 	service.endSession = endSession;

--- a/lib/caliper-service.js
+++ b/lib/caliper-service.js
@@ -689,8 +689,9 @@ function CaliperService(options) {
 
 		// create Event
 		var event = new Caliper.Events.SessionEvent();
+		var actor = didTimeOut ? softwareApplication : person;
 		var action = didTimeOut ? Caliper.Actions.SessionActions.TIMED_OUT : Caliper.Actions.SessionActions.LOGGED_OUT;
-		event.setActor(person);
+		event.setActor(actor);
 		event.setAction(action);
 		event.setObject(session);
 		event.setEventTime(endedAtTime);

--- a/lib/caliper-service.test.js
+++ b/lib/caliper-service.test.js
@@ -2,6 +2,9 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 chai.use(require('chai-things'));
 chai.use(chaiAsPromised);
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
 const expect = chai.expect;
 chai.should();
 const _ = require('lodash');
@@ -21,8 +24,8 @@ function getOptions(store) {
 		},
 		appId: 'https://app.example.edu',
 		appName: 'Example App',
-		getToken: function() {
-			return new Promise(function(resolve, reject){
+		getToken: function () {
+			return new Promise(function (resolve, reject) {
 				resolve({
 					accessToken: 'THIS_IS_NOT_A_REAL_ACCESS_TOKEN',
 					expires: 'Thu, 09 Feb 2017 06:08:58 GMT'
@@ -30,73 +33,73 @@ function getOptions(store) {
 			});
 		},
 		storageService: {
-			getItem: function(key) {
+			getItem: function (key) {
 				return store[key];
 			},
-			setItem: function(key, value) {
+			setItem: function (key, value) {
 				store[key] = value;
 			},
-			removeItem: function(key) {
+			removeItem: function (key) {
 				delete store[key]
 			}
 		}
 	};
 }
 
-describe('CaliperService', function() {
-	describe('ctor', function(){
-		it('requires options parameter', function() {
+describe('CaliperService', function () {
+	describe('ctor', function () {
+		it('requires options parameter', function () {
 			expect(() => new CaliperService()).to.throw(Error);
 			expect(() => new CaliperService(null)).to.throw(Error);
 		});
-		it('succeeds with valid options', function() {
+		it('succeeds with valid options', function () {
 			expect(() => new CaliperService(getOptions())).to.not.throw(Error);
 		});
 	});
-	describe('validateOptions', function() {
-		it('requires sensorId, type string', function() {
+	describe('validateOptions', function () {
+		it('requires sensorId, type string', function () {
 			var options = getOptions();
 			options.sensorId = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 			delete options.sensorId;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires sensorOptions, plain object', function() {
+		it('requires sensorOptions, plain object', function () {
 			var options = getOptions();
 			options.sensorOptions = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 			delete options.sensorOptions;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires appId, type string', function() {
+		it('requires appId, type string', function () {
 			var options = getOptions();
 			options.appId = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 			delete options.appId;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires appName, type string', function() {
+		it('requires appName, type string', function () {
 			var options = getOptions();
 			options.appName = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 			delete options.appName;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires getToken, type function', function() {
+		it('requires getToken, type function', function () {
 			var options = getOptions();
 			options.getToken = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 			delete options.getToken;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires storageService, type object', function() {
+		it('requires storageService, type object', function () {
 			var options = getOptions();
 			options.storageService = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 			delete options.storageService;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires storageService.getItem, type function', function() {
+		it('requires storageService.getItem, type function', function () {
 			var options = getOptions();
 			options.storageService = {};
 			expect(() => new CaliperService(options)).to.throw(Error);
@@ -105,53 +108,58 @@ describe('CaliperService', function() {
 			};
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires storageService.setItem, type function', function() {
+		it('requires storageService.setItem, type function', function () {
 			var options = getOptions();
 			options.storageService = {
-				getItem: function() {}
+				getItem: function () {}
 			};
 			expect(() => new CaliperService(options)).to.throw(Error);
 			options.storageService.setItem = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('requires storageService.removeItem, type function', function() {
+		it('requires storageService.removeItem, type function', function () {
 			var options = getOptions();
 			options.storageService = {
-				getItem: function() {},
-				setItem: function() {}
+				getItem: function () {},
+				setItem: function () {}
 			};
 			expect(() => new CaliperService(options)).to.throw(Error);
 			options.storageService.removeItem = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('autoSend, type boolean', function() {
+		it('autoSend, type boolean', function () {
 			var options = getOptions();
 			options.autoSend = 'string';
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('sendInterval, type number', function() {
+		it('sendInterval, type number', function () {
 			var options = getOptions();
 			options.sendInterval = 'string';
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('sessionIriPrefix, type string, not empty', function() {
+		it('sessionIriPrefix, type string, not empty', function () {
 			var options = getOptions();
 			options.sessionIriPrefix = 1;
 			expect(() => new CaliperService(options)).to.throw(Error);
 			options.sessionIriPrefix = '';
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('sessionEndThreshold, type number', function() {
+		it('sessionTimeoutThreshold, type number', function () {
 			var options = getOptions();
-			options.sessionEndThreshold = 'string';
+			options.sessionTimeoutThreshold = 'string';
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('sessionKeepAliveThreshold, type number', function() {
+		it('sessionKeepAliveThreshold, type number', function () {
 			var options = getOptions();
 			options.sessionKeepAliveThreshold = 'string';
 			expect(() => new CaliperService(options)).to.throw(Error);
 		});
-		it('onError, type function', function() {
+		it('activityUpdateThreshold, type number', function () {
+			var options = getOptions();
+			options.activityUpdateThreshold = 'string';
+			expect(() => new CaliperService(options)).to.throw(Error);
+		});
+		it('onError, type function', function () {
 			var options = getOptions();
 			options.onError = 'string';
 			expect(() => new CaliperService(options)).to.throw(Error);
@@ -166,43 +174,45 @@ describe('CaliperService', function() {
 		'edu.bobloblawslawfirm.foo': 'bar'
 	};
 
-	function resetService(store) {
-		caliperService = new CaliperService(getOptions(store))
+	function resetService(store, options) {
+		options = options || {};
+		options = _.merge(getOptions(store), options);
+		caliperService = new CaliperService(options);
 	}
 
 	function setPerson() {
 		caliperService.setPerson(id, firstName, lastName);
 	}
 
-	describe('isInitialized', function() {
+	describe('isInitialized', function () {
 		resetService();
-		it('returns true after init', function() {
+		it('returns true after init', function () {
 			expect(caliperService.isInitialized()).to.be.true;
 		});
 	});
-	describe('setPerson', function() {
+	describe('setPerson', function () {
 		resetService();
-		it('requires id, firstName, lastName', function() {
+		it('requires id, firstName, lastName', function () {
 			expect(() => caliperService.setPerson()).to.throw(Error);
 			expect(() => caliperService.setPerson(id)).to.throw(Error);
 			expect(() => caliperService.setPerson(id, firstName)).to.throw(Error);
 			expect(() => setPerson()).to.not.throw(Error);
 		});
-		it('validates extensions, type object', function() {
+		it('validates extensions, type object', function () {
 			expect(() => caliperService.setPerson(id, firstName, lastName, 'string')).to.throw(Error);
 			expect(() => caliperService.setPerson(id, firstName, lastName, extensions)).to.not.throw(Error);
 		});
 	});
-	describe('startSession', function() {
-		it('succeeds', function() {
+	describe('startSession', function () {
+		it('succeeds', function () {
 			resetService();
 			setPerson();
 			expect(() => caliperService.startSession()).to.not.throw(Error);
 		});
-		it('succeeds if session is already active', function() {
+		it('succeeds if session is already active', function () {
 			expect(() => caliperService.startSession()).to.not.throw(Error);
 		});
-		it('validates extensions, type object', function() {
+		it('validates extensions, type object', function () {
 			resetService();
 			setPerson();
 			expect(() => caliperService.startSession('string')).to.throw(Error);
@@ -210,51 +220,195 @@ describe('CaliperService', function() {
 			setPerson();
 			expect(() => caliperService.startSession(extensions)).to.not.throw(Error);
 		});
-		it('requires setPerson to be called', function() {
+		it('requires setPerson to be called', function () {
 			resetService();
 			expect(() => caliperService.startSession()).to.throw(Error);
 		});
 	});
-	it('setPerson fails if session is active', function() {
+	it('setPerson fails if session is active', function () {
 		resetService();
 		setPerson();
 		caliperService.startSession();
 		expect(() => caliperService.setPerson('https://bobloblawslawfirm.edu/user/2', firstName, lastName)).to.throw(Error);
 	});
-	describe('endSession', function() {
-		it('succeeds', function() {
+	describe('endSession', function () {
+		it('succeeds', function () {
 			resetService();
 			setPerson();
 			caliperService.startSession();
 			expect(() => caliperService.endSession()).to.not.throw(Error);
 		});
-		it('requires setPerson to be called', function() {
+		it('requires setPerson to be called', function () {
 			resetService();
 			expect(() => caliperService.endSession()).to.throw(Error);
 		});
-		it('requires startSession to be called', function() {
+		it('requires startSession to be called', function () {
 			resetService();
 			setPerson();
 			expect(() => caliperService.endSession()).to.throw(Error);
 		});
 	});
 
-	describe('saved Session', function() {
+	describe('handleSavedSession', function () {
 		const store = {};
-		store['studioKit:caliperService:person'] = {};
-		store['studioKit:caliperService:session'] = {};
-
-		it('succeeds with recently paused Session', function() {
-			expect(() => {
-				store['studioKit:caliperService:sessionPauseDate'] = moment().toISOString();
-				resetService(store);
-			}).to.not.throw(Error);
+		it('clears saved data if no saved person', function () {
+			const store = {};
+			store['studioKit:caliperService:session'] = {};
+			store['studioKit:caliperService:lastActivityDate'] = moment().subtract(29, 'minutes').toISOString();
+			resetService(store);
+			expect(store['studioKit:caliperService:session']).to.equal(null);
+			expect(store['studioKit:caliperService:person']).to.equal(null);
+			expect(store['studioKit:caliperService:lastKeepAliveDate']).to.equal(null);
+			expect(store['studioKit:caliperService:lastActivityDate']).to.equal(null);
 		});
-		it('succeeds with old paused Session', function() {
-			expect(() => {
-				store['studioKit:caliperService:sessionPauseDate'] = moment().subtract(2, 'minutes').toISOString();
-				resetService(store);
-			}).to.not.throw(Error);
+		it('clears saved data if no saved lastActivityDate', function () {
+			const store = {};
+			store['studioKit:caliperService:session'] = {};
+			store['studioKit:caliperService:person'] = {};
+			resetService(store);
+			expect(store['studioKit:caliperService:session']).to.equal(null);
+			expect(store['studioKit:caliperService:person']).to.equal(null);
+			expect(store['studioKit:caliperService:lastKeepAliveDate']).to.equal(null);
+			expect(store['studioKit:caliperService:lastActivityDate']).to.equal(null);
+		});
+		it('resumes session if lastActivityDate is within sessionTimeoutThreshold (30 minutes)', function () {
+			const store = {};
+			store['studioKit:caliperService:session'] = {
+				'@id': 'https://app.example.edu/session/89d9951f-c026-4702-8abd-f4a1705467b2',
+			};
+			store['studioKit:caliperService:person'] = {};
+			store['studioKit:caliperService:lastActivityDate'] = moment().subtract(29, 'minutes').toISOString();
+			resetService(store);
+			expect(store['studioKit:caliperService:session']['@id']).to.equal('https://app.example.edu/session/89d9951f-c026-4702-8abd-f4a1705467b2');
+		});
+		it('starts new session if lastActivityDate is past sessionTimeoutThreshold (30 minutes)', function () {
+			const store = {};
+			store['studioKit:caliperService:session'] = {
+				'@id': 'https://app.example.edu/session/89d9951f-c026-4702-8abd-f4a1705467b2',
+			};
+			store['studioKit:caliperService:person'] = {};
+			store['studioKit:caliperService:lastActivityDate'] = moment().subtract(31, 'minutes').toISOString();
+			resetService(store);
+			expect(store['studioKit:caliperService:session']['@id']).to.not.equal('https://app.example.edu/session/89d9951f-c026-4702-8abd-f4a1705467b2');
+		});
+	});
+
+	describe('session time-out, keep-alive', function () {
+		let clock;
+		let store = {};
+		const options = {
+			autoSend: false,
+			sessionTimeoutThreshold: 1000 * 5,
+			sessionKeepAliveThreshold: 1000 * 2.5,
+			activityUpdateThreshold: 1000
+		};
+		beforeEach(function () {
+			store = {};
+			clock = sinon.useFakeTimers();
+			resetService(store, options);
+			setPerson();
+			caliperService.startSession();
+		});
+
+		afterEach(function () {
+			clock.restore();
+		});
+
+		it('onActivity is limited to activityUpdateThreshold', function() {
+			var lastActivityDate = store['studioKit:caliperService:lastActivityDate'];
+			caliperService.onActivity();
+			clock.tick(options.activityUpdateThreshold / 2);
+			caliperService.onActivity();
+			expect(store['studioKit:caliperService:lastActivityDate']).to.equal(lastActivityDate);
+			clock.tick(options.activityUpdateThreshold);
+			caliperService.onActivity();
+			expect(store['studioKit:caliperService:lastActivityDate']).to.not.equal(lastActivityDate);
+		});
+
+		it('time-out happens with no activity after sessionTimeoutThreshold', function () {
+			// session started
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			clock.tick(options.sessionTimeoutThreshold - 1);
+			// session almost timed out, still exists
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			clock.tick(1);
+			// session timed out, is null
+			expect(store['studioKit:caliperService:session']).to.equal(null);
+		});
+
+		it('activity delays time-out', function () {
+			// session started
+			// times out at options.sessionTimeoutThreshold
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			var id = store['studioKit:caliperService:session']['@id'];
+			clock.tick(options.sessionTimeoutThreshold - 1);
+			// session almost timed out, still exists
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			// trigger activity before time out
+			// now times out at `(options.sessionTimeoutThreshold - 1) + options.sessionTimeoutThreshold`
+			caliperService.onActivity();
+			clock.tick(1);
+			// original time out limit, session still exists
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			clock.tick(options.sessionTimeoutThreshold - 2);
+			// session almost timed out, still exists
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			// same session as start
+			expect(store['studioKit:caliperService:session']['@id']).to.equal(id);
+		});
+
+		it('activity after time-out starts a new session', function () {
+			// session started
+			var id = store['studioKit:caliperService:session']['@id'];
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			clock.tick(options.sessionTimeoutThreshold);
+			// session timed out, null
+			expect(store['studioKit:caliperService:session']).to.equal(null);
+			caliperService.onActivity();
+			// new session
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			// make sure it is a different session
+			expect(store['studioKit:caliperService:session']['@id']).to.not.equal(id);
+		});
+
+		it('media playing delays time-out', function () {
+			var stub = sinon.stub(caliperService, 'isMediaPlaying').callsFake(function() {
+				return true;
+			});
+
+			// session started
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			var id = store['studioKit:caliperService:session']['@id'];
+			clock.tick(options.sessionTimeoutThreshold - 1);
+			// session almost timed out, still exists
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			clock.tick(1);
+			// should have timed out, but isMediaPlaying causes it to still exist
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			// same session as start
+			expect(store['studioKit:caliperService:session']['@id']).to.equal(id);
+
+			caliperService.isMediaPlaying.restore();
+		});
+
+		it('keep-alive succeeds onActivity after sessionKeepAliveThreshold', function () {
+			// session started
+			expect(store['studioKit:caliperService:session']).to.not.equal(null);
+			var id = store['studioKit:caliperService:session']['@id'];
+			var dateModified = store['studioKit:caliperService:session']['dateModified'];
+
+			// move before threshold
+			clock.tick(options.sessionKeepAliveThreshold - options.activityUpdateThreshold);
+			caliperService.onActivity();
+			expect(store['studioKit:caliperService:session']['dateModified']).to.equal(dateModified);
+			
+			// move past threshold
+			clock.tick(options.activityUpdateThreshold);
+			caliperService.onActivity();
+			
+			// same session, new dateModified
+			expect(store['studioKit:caliperService:session']['@id']).to.equal(id);
+			expect(store['studioKit:caliperService:session']['dateModified']).to.not.equal(dateModified);
 		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studiokit-caliper-js",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Common library of services used to instrument applications with Caliper JS",
   "keywords": [
     "purdue",


### PR DESCRIPTION
fixes and tests for Session Time Out and Keep-Alive logic  …
- rename `sessionEndThreshold` to `sessionTimeoutThreshold`
- add `activityUpdateThreshold` option
- persist sessionExtensions to storage, for start of new session after a timeout
- ending idle sessions uses the `TIMED_OUT` Caliper Action
- timed out sessions do not clear Person and LastActivityDate, in order to allow restart
- onActivity() now correctly starts a new session after a timeout
- add unit tests for time out and keep-alive cases
- expose isMediaPlaying to allow use by unit test stubs